### PR TITLE
proposed solution to #70

### DIFF
--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -410,7 +410,20 @@ function msgReceived(msg, rinfo) {
     try {
         pkt = parse(msg);
     } catch (error) {
-        return self.emit('error', error);
+        // cancel completely this request
+        // console.warn('Error while parsing response, maybe a malformed package has been received...');
+        console.warn('Error while parsing response, maybe a malformed package has been received...');
+
+        console.error('Message that caused the error:');
+        var hex = msg.toString('hex');
+        while (hex.length > 0) {
+            console.error('    ' + hex.slice(0, 32).replace(/([0-9a-f]{2})/g, '$1 '));
+            hex = hex.slice(32);
+        }    
+
+        var response = self.reqs[Object.keys(self.reqs)[0]].callback(new Error("problem parsing response, malformed packet?"));
+        clearRequest(self.reqs, Object.keys(self.reqs)[0]);
+        return response;
     }
 
     // If this message's request id matches one we've sent,


### PR DESCRIPTION
Avoid exit on AssertionError #70

When a malformed package is found, an error message is left in the log with the sample of the package that originated it.
There is no exception or cause stop the program.
Is my first PR, so I'm not sure if I are doing this fine.